### PR TITLE
chore: add license and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+This is a personal template repository tailored to my specific workflow and preferences.
+
+That said, if you spot bugs, typos, or have suggestions for improvements, feel free to open an issue or PR. Just keep in mind that I may not accept changes that conflict with my personal preferences or use cases.
+
+Thanks for your interest!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ben Hanzl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Adds an MIT license and `CONTRIBUTING.md`  doc to set expectations of public usage.

## Type of Change

<!-- Check the type that applies (aligns with conventional commits) -->

- [x] docs: Documentation update

## Affected Packages

<!-- List affected workspace packages (e.g., @repo/eslint-config, apps/example) -->

n/a

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
