### PR TITLE
chore(claude): expand allowed bash commands for improved workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,8 @@
   "permissions": {
     "disableBypassPermissionsMode": "disable",
     "allow": [
+      "Bash(cat *)",
+      "Bash(find *)",
       "Bash(gh pr checks *)",
       "Bash(gh pr diff *)",
       "Bash(gh pr list *)",
@@ -19,7 +21,9 @@
       "Bash(git push)",
       "Bash(git show *)",
       "Bash(git status *)",
-      "Bash(pnpm *)"
+      "Bash(ls *)",
+      "Bash(pnpm *)",
+      "Bash(tree *)"
     ],
     "ask": [
       "Bash(gh pr close *)",


### PR DESCRIPTION
## Summary

Expanded the allowed bash command permissions in Claude settings to include commonly needed file exploration commands (`cat`, `find`, `ls`, `tree`). These additions streamline development workflows while maintaining security through explicit permission allowlisting.

## Type of Change

- [x] chore: Build/tooling changes

## Affected Packages

- `.claude/settings.json` (repository configuration)

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally (`pnpm test`) - N/A, configuration change only
- [x] Linting passes (`pnpm lint`) - Applied via pre-commit hook
- [x] Type checking passes (`pnpm typecheck`) - N/A, configuration change only
- [x] Build succeeds (`pnpm build`) - N/A, configuration change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)