### PR TITLE
fix(renovate): correct regex patterns in package name matchers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,21 +37,21 @@
       "matchUpdateTypes": ["major"],
       "groupName": "TypeScript ecosystem (major)",
       "semanticCommitScope": "typescript",
-      "matchPackageNames": ["/^typescript/", "/^@typescript-eslint//"]
+      "matchPackageNames": ["/^typescript/", "/^@typescript-eslint/"]
     },
     {
       "description": "Group ESLint ecosystem major updates",
       "matchUpdateTypes": ["major"],
       "groupName": "ESLint ecosystem (major)",
       "semanticCommitScope": "eslint",
-      "matchPackageNames": ["/^eslint/", "/^@eslint//"]
+      "matchPackageNames": ["/^eslint/", "/^@eslint/"]
     },
     {
       "description": "Group Vitest ecosystem major updates",
       "matchUpdateTypes": ["major"],
       "groupName": "Vitest ecosystem (major)",
       "semanticCommitScope": "vitest",
-      "matchPackageNames": ["/^vitest/", "/^@vitest//"]
+      "matchPackageNames": ["/^vitest/", "/^@vitest/"]
     },
     {
       "description": "Package manager updates (manual review required)",


### PR DESCRIPTION
## Summary

Fixed incorrect regex patterns in renovate.json that had trailing double slashes, causing regex syntax errors in package name matchers.

## Type of Change

- [x] fix: Bug fix

## Affected Packages

Configuration only (no workspace packages affected directly)

## Details

The `matchPackageNames` patterns for three ecosystem groups had incorrect regex syntax with double trailing slashes:
- `"/^@typescript-eslint//"` → `"/^@typescript-eslint/"`
- `"/^@eslint//"` → `"/^@eslint/"`
- `"/^@vitest//"` → `"/^@vitest/"`

This fix ensures Renovate can properly match scoped packages in these ecosystems for major version updates.

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)