### PR TITLE
chore(husky): migrate pre-commit hook to use pnpm exec

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx --no-install lint-staged
+pnpm exec lint-staged


### PR DESCRIPTION
## Summary

Updates the Husky pre-commit hook to use `pnpm exec lint-staged` instead of `npx --no-install lint-staged` to align with the project's pnpm-first approach.

## Type of Change

- [x] chore: Build/tooling changes

## Affected Packages

- Root configuration (`.husky/pre-commit`)

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)